### PR TITLE
fix(codex): keep Team workspace seats in separate slots

### DIFF
--- a/src/claude_swap/codex.py
+++ b/src/claude_swap/codex.py
@@ -308,25 +308,27 @@ class CodexAccountSwitcher:
         email: str,
         account_id: str,
     ) -> str | None:
-        """Find the slot holding this login.
+        """Find the slot holding this login, identified by email *and* workspace.
 
-        Seats in one ChatGPT Team workspace share a ``chatgpt_account_id``, so the
-        workspace id on its own cannot tell two logins apart. Match on both fields
-        first, then on the email, which is what actually distinguishes seats.
+        Neither field identifies a login on its own. Seats in one ChatGPT Team
+        workspace share a ``chatgpt_account_id``, and one person can hold seats
+        in several workspaces under a single email. Matching on either field
+        alone therefore collapses two distinct logins onto one slot, and that
+        slot's stored credentials are then overwritten with the other login's
+        tokens -- the failure this helper exists to prevent, in one direction or
+        the other.
 
-        There is deliberately no workspace-only fallback. It would fire exactly
-        when a sibling seat of a registered workspace is live but not yet added,
-        and resolve that unknown login onto the registered seat's slot -- the
-        credential file it would then overwrite. Returning ``None`` instead lets
-        the unmanaged-login guard in :meth:`switch_to` refuse, which is safer than
-        guessing which seat is live.
+        So anything short of an exact match is ``None``, which callers read as
+        "not managed here": :meth:`add_account` allocates a new slot instead of
+        claiming an existing one, and :meth:`switch_to` refuses rather than
+        writing the live login into a slot that may belong to someone else. A
+        renamed login is the cost -- it needs a fresh ``add`` -- and that is a
+        far better trade than silently destroying a login.
         """
-        items = list(accounts.items())
-        for number, account in items:
+        if not email:
+            return None
+        for number, account in accounts.items():
             if account.get("accountId") == account_id and account.get("email") == email:
-                return number
-        for number, account in items:
-            if account.get("email") == email:
                 return number
         return None
 
@@ -343,8 +345,11 @@ class CodexAccountSwitcher:
         with FileLock(self.lock_file):
             self._setup_directories()
             data = self._read_sequence()
-            # A different email in the same workspace is a different seat, so it must
-            # never resolve onto an existing slot and overwrite that login's tokens.
+            # Only the very same login may claim an occupied slot. A different
+            # seat in this workspace, or this email in a different workspace, is
+            # a separate login and gets its own slot -- resolving either onto an
+            # existing slot would overwrite that login's tokens without asking,
+            # since the prompt below is skipped when number == existing.
             existing = self._match_account_number(data["accounts"], email, account_id)
             number = str(slot) if slot is not None else existing or self._next_number(data)
             if not number.isdigit() or int(number) < 1:

--- a/src/claude_swap/codex.py
+++ b/src/claude_swap/codex.py
@@ -302,14 +302,41 @@ class CodexAccountSwitcher:
         data = self._read_sequence()
         return self._current_account_for_auth(auth, data)
 
+    @staticmethod
+    def _match_account_number(
+        accounts: dict[str, Any],
+        email: str,
+        account_id: str,
+        *,
+        allow_workspace_only: bool = True,
+    ) -> str | None:
+        """Find the slot holding this login.
+
+        Seats in one ChatGPT Team workspace share a ``chatgpt_account_id``, so the
+        workspace id on its own cannot tell two logins apart. Match on both fields
+        first, then on the email, which is what actually distinguishes seats. A
+        workspace-only match stays available for a login stored before its email
+        changed, but only while a single slot carries that id.
+        """
+        items = list(accounts.items())
+        for number, account in items:
+            if account.get("accountId") == account_id and account.get("email") == email:
+                return number
+        for number, account in items:
+            if account.get("email") == email:
+                return number
+        if not allow_workspace_only:
+            return None
+        shared = [
+            number for number, account in items if account.get("accountId") == account_id
+        ]
+        return shared[0] if len(shared) == 1 else None
+
     def _current_account_for_auth(
         self, auth: dict[str, Any], data: dict[str, Any]
     ) -> str | None:
         email, account_id, _mode = self._identity_from_auth(auth)
-        for number, account in data["accounts"].items():
-            if account.get("accountId") == account_id or account.get("email") == email:
-                return number
-        return None
+        return self._match_account_number(data["accounts"], email, account_id)
 
     def add_account(self, slot: int | None = None, assume_yes: bool = False) -> None:
         live_auth = self._read_live_auth()
@@ -318,13 +345,10 @@ class CodexAccountSwitcher:
         with FileLock(self.lock_file):
             self._setup_directories()
             data = self._read_sequence()
-            existing = next(
-                (
-                    number
-                    for number, account in data["accounts"].items()
-                    if account.get("accountId") == account_id or account.get("email") == email
-                ),
-                None,
+            # A different email in the same workspace is a different seat, so it must
+            # never resolve onto an existing slot and overwrite that login's tokens.
+            existing = self._match_account_number(
+                data["accounts"], email, account_id, allow_workspace_only=False
             )
             number = str(slot) if slot is not None else existing or self._next_number(data)
             if not number.isdigit() or int(number) < 1:

--- a/src/claude_swap/codex.py
+++ b/src/claude_swap/codex.py
@@ -307,16 +307,19 @@ class CodexAccountSwitcher:
         accounts: dict[str, Any],
         email: str,
         account_id: str,
-        *,
-        allow_workspace_only: bool = True,
     ) -> str | None:
         """Find the slot holding this login.
 
         Seats in one ChatGPT Team workspace share a ``chatgpt_account_id``, so the
         workspace id on its own cannot tell two logins apart. Match on both fields
-        first, then on the email, which is what actually distinguishes seats. A
-        workspace-only match stays available for a login stored before its email
-        changed, but only while a single slot carries that id.
+        first, then on the email, which is what actually distinguishes seats.
+
+        There is deliberately no workspace-only fallback. It would fire exactly
+        when a sibling seat of a registered workspace is live but not yet added,
+        and resolve that unknown login onto the registered seat's slot -- the
+        credential file it would then overwrite. Returning ``None`` instead lets
+        the unmanaged-login guard in :meth:`switch_to` refuse, which is safer than
+        guessing which seat is live.
         """
         items = list(accounts.items())
         for number, account in items:
@@ -325,12 +328,7 @@ class CodexAccountSwitcher:
         for number, account in items:
             if account.get("email") == email:
                 return number
-        if not allow_workspace_only:
-            return None
-        shared = [
-            number for number, account in items if account.get("accountId") == account_id
-        ]
-        return shared[0] if len(shared) == 1 else None
+        return None
 
     def _current_account_for_auth(
         self, auth: dict[str, Any], data: dict[str, Any]
@@ -347,9 +345,7 @@ class CodexAccountSwitcher:
             data = self._read_sequence()
             # A different email in the same workspace is a different seat, so it must
             # never resolve onto an existing slot and overwrite that login's tokens.
-            existing = self._match_account_number(
-                data["accounts"], email, account_id, allow_workspace_only=False
-            )
+            existing = self._match_account_number(data["accounts"], email, account_id)
             number = str(slot) if slot is not None else existing or self._next_number(data)
             if not number.isdigit() or int(number) < 1:
                 raise ValidationError("Codex account slot must be a positive integer")

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -159,6 +159,31 @@ def test_switch_away_from_a_shared_workspace_seat_keeps_both_logins(switcher):
     )
 
 
+def test_unregistered_sibling_seat_is_not_mistaken_for_a_managed_one(switcher):
+    instance, home = switcher
+    _write_live(home, _auth("one@example.com", "shared-workspace"))
+    instance.add_account(assume_yes=True)
+    _write_live(home, _auth("two@example.com", "shared-workspace"))
+
+    assert instance.current_account_number() is None
+
+
+def test_switching_away_from_an_unregistered_sibling_seat_is_refused(switcher):
+    instance, home = switcher
+    _write_live(home, _auth("one@example.com", "shared-workspace"))
+    instance.add_account(assume_yes=True)
+    _write_live(home, _auth("elsewhere@example.com", "other-workspace"))
+    instance.add_account(assume_yes=True)
+    _write_live(home, _auth("two@example.com", "shared-workspace"))
+
+    with pytest.raises(SwitchError, match="unmanaged"):
+        instance.switch_to("2", json_output=True)
+
+    assert json.loads((instance.credentials_dir / "account-1.json").read_text()) == _auth(
+        "one@example.com", "shared-workspace"
+    )
+
+
 def test_api_key_accounts_get_a_stable_non_secret_label(switcher):
     instance, home = switcher
     _write_live(

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -184,6 +184,54 @@ def test_switching_away_from_an_unregistered_sibling_seat_is_refused(switcher):
     )
 
 
+def test_the_same_email_in_two_workspaces_keeps_separate_slots(switcher):
+    instance, home = switcher
+    _write_live(home, _auth("same@example.com", "workspace-one"))
+    instance.add_account(assume_yes=True)
+
+    _write_live(home, _auth("same@example.com", "workspace-two"))
+    instance.add_account(assume_yes=True)
+
+    assert [account["number"] for account in instance.list_accounts()["accounts"]] == [1, 2]
+    assert json.loads((instance.credentials_dir / "account-1.json").read_text()) == _auth(
+        "same@example.com", "workspace-one"
+    )
+
+
+def test_a_renamed_login_is_not_claimed_by_its_old_slot(switcher):
+    instance, home = switcher
+    _write_live(home, _auth("old@example.com", "account-one"))
+    instance.add_account(assume_yes=True)
+
+    _write_live(home, _auth("new@example.com", "account-one"))
+
+    assert instance.current_account_number() is None
+
+
+def test_an_unreadable_live_identity_matches_nothing(switcher):
+    instance, home = switcher
+    _write_live(home, _auth("one@example.com", "account-one"))
+    instance.add_account(assume_yes=True)
+    _write_live(home, _auth("two@example.com", "account-two"))
+    instance.add_account(assume_yes=True)
+
+    # Legacy metadata with blank fields must not be matched by a login whose
+    # own identity failed to decode; switch_to reads auth.json directly and so
+    # never sees the validation _read_live_auth applies.
+    sequence = json.loads(instance.sequence_file.read_text())
+    sequence["accounts"]["1"]["email"] = ""
+    sequence["accounts"]["1"]["accountId"] = ""
+    instance.sequence_file.write_text(json.dumps(sequence), encoding="utf-8")
+    _write_live(home, {"auth_mode": "chatgpt", "tokens": {"id_token": "not-a-jwt"}})
+
+    with pytest.raises(SwitchError, match="unmanaged"):
+        instance.switch_to("2", json_output=True)
+
+    assert json.loads((instance.credentials_dir / "account-1.json").read_text()) == _auth(
+        "one@example.com", "account-one"
+    )
+
+
 def test_api_key_accounts_get_a_stable_non_secret_label(switcher):
     instance, home = switcher
     _write_live(

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -110,6 +110,55 @@ def test_switch_refuses_to_overwrite_an_unmanaged_live_login(switcher):
     assert json.loads((home / "auth.json").read_text()) == unmanaged
 
 
+def test_seats_sharing_a_workspace_keep_their_own_slots(switcher):
+    instance, home = switcher
+    _write_live(home, _auth("one@example.com", "shared-workspace"))
+    instance.add_account(assume_yes=True)
+
+    _write_live(home, _auth("two@example.com", "shared-workspace"))
+    instance.add_account(assume_yes=True)
+
+    listed = instance.list_accounts()
+    assert [account["email"] for account in listed["accounts"]] == [
+        "one@example.com",
+        "two@example.com",
+    ]
+    assert json.loads((instance.credentials_dir / "account-1.json").read_text()) == _auth(
+        "one@example.com", "shared-workspace"
+    )
+
+
+def test_live_seat_is_identified_by_email_not_just_workspace(switcher):
+    instance, home = switcher
+    _write_live(home, _auth("one@example.com", "shared-workspace"))
+    instance.add_account(assume_yes=True)
+    _write_live(home, _auth("two@example.com", "shared-workspace"))
+    instance.add_account(slot=2, assume_yes=True)
+
+    assert instance.current_account_number() == "2"
+
+
+def test_switch_away_from_a_shared_workspace_seat_keeps_both_logins(switcher):
+    instance, home = switcher
+    _write_live(home, _auth("one@example.com", "shared-workspace"))
+    instance.add_account(assume_yes=True)
+    _write_live(home, _auth("two@example.com", "shared-workspace"))
+    instance.add_account(slot=2, assume_yes=True)
+
+    result = instance.switch_to("1", json_output=True)
+
+    assert result["switched"]
+    assert json.loads((home / "auth.json").read_text()) == _auth(
+        "one@example.com", "shared-workspace"
+    )
+    assert json.loads((instance.credentials_dir / "account-1.json").read_text()) == _auth(
+        "one@example.com", "shared-workspace"
+    )
+    assert json.loads((instance.credentials_dir / "account-2.json").read_text()) == _auth(
+        "two@example.com", "shared-workspace"
+    )
+
+
 def test_api_key_accounts_get_a_stable_non_secret_label(switcher):
     instance, home = switcher
     _write_live(


### PR DESCRIPTION
Issues are disabled on this repo, so I'm sending this as a PR instead — happy to move the report to an issue if you'd prefer. (`.github/ISSUE_TEMPLATE/bug_report.yml` exists and the README says "fork it, file issues, send PRs", so the setting may be unintentional.)

## The problem

Two ChatGPT logins that are separate **seats in the same Team workspace** share one `chatgpt_account_id`. `ccswap codex` keys accounts by that id, so it cannot tell such seats apart — and adding the second one destroys the first one's stored login.

Reproduced with ccswap 0.23.0 (uv, Windows 11). `src/claude_swap/codex.py` is byte-identical between 0.23.0 and current `main`, so every line reference below still resolves.

### Symptom 1 — `codex add` overwrites the first seat in place

```console
$ codex login          # seat A, Team workspace W
$ ccswap codex add
Added Codex Account 1: a@example.com

$ codex login          # seat B — different user, same workspace W
$ ccswap codex add
Added Codex Account 1: b@example.com     # same slot; A's tokens are gone
```

`ccswap list --provider codex` afterwards shows only B. Nothing prompts, and both lines claim success.

### Symptom 2 — switching to the shadowed seat is a silent no-op

With A in slot 1, B in slot 3 (added via an explicit `--slot`), and B the live login:

```console
$ ccswap codex status
Codex Account 1: a@example.com [Codex Team] (active)   # wrong — B is live

$ ccswap codex switch 1 ; echo "exit=$?"
exit=0                                                 # no output, nothing switched
```

### Symptom 3 — switching away writes the live login into the wrong slot

```console
$ ccswap codex switch 2 && ccswap codex switch 1
# credentials/account-1.json now holds B's tokens
```

I recovered seat A only because I had taken a filesystem backup first.

## Root cause

`_identity_from_auth` (`codex.py:243`) derives identity from `tokens.account_id` / `chatgpt_account_id`, which is the **workspace** id, not the user — Team seats share it. Both lookups then match on `accountId` **or** `email` and return the first hit:

- `_current_account_for_auth` (`codex.py:305-312`) resolves to slot 1 whenever any seat of that workspace is live. It feeds `switch_to`'s `already-active` check (`codex.py:386`), the pre-switch save at `codex.py:398-399` — which is the credential loss — and `_refresh_inactive_auth` (`codex.py:678`).
- `add_account` (`codex.py:321-329`) resolves `existing` to slot 1, so a new seat overwrites it.

The id token does distinguish the seats: `https://api.openai.com/auth.user_id` and `sub` differ, while `chatgpt_account_id` is identical.

## The fix

A single helper, `_match_account_number`, backs both lookups. A login is identified by its `accountId` **and** `email` together, and anything short of that exact pair returns `None`.

Neither field identifies a login on its own, and each loose branch destroys credentials in its own direction:

- **Workspace id alone** — seats in one Team workspace share it. That is the bug reported above.
- **Email alone** — one person can hold seats in several workspaces under a single email. The second login then resolves onto the first one's slot, `add_account` overwrites its credentials *without prompting* (the prompt at `codex.py:333` is suppressed when `number == existing`), and `switch_to` reports `already-active`. This is symptom 1 with the collision dimensions swapped.

Two earlier revisions of this branch each kept one of those branches, and each left a live credential-destroying path. Both are now gone; the commits are kept separate so the reasoning is reviewable.

`None` means "not managed here", so `add_account` allocates a new slot and `switch_to` refuses through the existing unmanaged-login guard. The cost is that a renamed login needs a fresh `add` instead of being adopted by its old slot — the safe direction to fail in.

An empty identity is refused too. `_identity_from_auth` returns `("", "", mode)` for a token it cannot decode, and `switch_to` and `_refresh_inactive_auth` read `auth.json` directly via `_read_json`, bypassing the validation `_read_live_auth` applies at `codex.py:228` — so a malformed live login could otherwise match legacy metadata with blank fields and overwrite its backup.

A sturdier identity would be the stable principal plus the workspace, `(sub`/`user_id, chatgpt_account_id)`, which survives an email change as well. That needs a migration for slots already on disk, so I left it out of a bugfix; happy to follow up if you want it.

## Tests

Eight regression tests in `tests/test_codex.py`. **All eight fail against `main` and pass on this branch** — verified by running them with `codex.py` reverted to `380627c`:

| test | covers |
|---|---|
| `test_seats_sharing_a_workspace_keep_their_own_slots` | symptom 1 |
| `test_live_seat_is_identified_by_email_not_just_workspace` | symptom 2 |
| `test_switch_away_from_a_shared_workspace_seat_keeps_both_logins` | symptom 3 |
| `test_unregistered_sibling_seat_is_not_mistaken_for_a_managed_one` | sibling seat live but not yet added |
| `test_switching_away_from_an_unregistered_sibling_seat_is_refused` | ditto, credential file intact |
| `test_the_same_email_in_two_workspaces_keeps_separate_slots` | the mirrored collision |
| `test_a_renamed_login_is_not_claimed_by_its_old_slot` | email change is not adopted by workspace id |
| `test_an_unreadable_live_identity_matches_nothing` | undecodable token vs. blank legacy metadata |

They bind the implementation rather than merely passing: replacing the exact pair with an email-only match fails `test_the_same_email_in_two_workspaces_keeps_separate_slots`, and dropping the empty-identity guard fails `test_an_unreadable_live_identity_matches_nothing`.

Full suite on Windows: **1834 passed, 47 skipped**. `uv sync --locked` is unaffected — no lockfile, `pyproject.toml` or README changes.

## Note

The emails and ids above are placeholders for two real seats in one Team workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
